### PR TITLE
fix(format-line): curly brace in tick should not be auto-spaced: necessary for regex

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -11,7 +11,7 @@ function formatLine(line, indentLevel, indentStr) {
   }
 
   trimmed = trimmed.replace(/\s+/g, " ");
-  trimmed = trimmed.replace(/\s*\{/g, " {");
+  trimmed = addSpaceBeforeOpenBraceOutsideBackticks(trimmed);
   trimmed = trimmed.replace(/\[\s*(.*?)\s*\]/g, "[$1]");
 
   let newIndentLevel = indentLevel;
@@ -27,6 +27,33 @@ function formatLine(line, indentLevel, indentStr) {
     newLine,
     newIndentLevel,
   };
+}
+
+function addSpaceBeforeOpenBraceOutsideBackticks(line) {
+  let result = "";
+  let inBacktick = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === "`") {
+      inBacktick = !inBacktick;
+      result += ch;
+      continue;
+    }
+    if (ch === "{" && !inBacktick) {
+      if (result.length === 0 || result.endsWith(" ")) {
+        // If the { is already at the start of the line (result.length === 0)
+        // or the previous character is already a space (result.endsWith(" ")),
+        // we just append { as‑is.
+        result += "{";
+      } else {
+        result += " {";
+      }
+      continue;
+    }
+  }
+
+  return result;
 }
 
 function insertNewLinesBetweenBlocks(lines) {


### PR DESCRIPTION
Hello, fellow dev! Great job with the DBML formatter! My team has found it extremely useful.

My team ran into a formatting issue that breaks regex quantifiers in backticked `check` expressions.

Since `checks` syntax isn’t supported in the DBML version this formatter uses, my team agreed to keep `checks` in comments to avoid formatting error, but they are considered applicable. However, this is not the issue.

The issue is: the formatter currently inserts spaces " " before "{" everywhere, including inside backticks, so "{4}" becomes " {4}" (e.g., `[0-9]{4}` becomes `[0-9] {4}`). So, if that happens in a regex, that will change the regex meaning and cause a problem.

```dbml
Table members {
  ...

  /*
  checks {
    ...
    `birth_date IS NULL OR birth_date ~ '^[0-9] {4}(-[0-9] {2}(-[0-9] {2})?)?$'` [name: 'ck_members_birth_date_fmt_valid']
  }

  */

}
```

Proposed fix:

- If `{` is inside backticks, do **not** auto-space it.
- Otherwise, keep the current auto-spacing behavior.

Expected result (regex remains intact):

```dbml

  /*
  checks {
    ...
    `birth_date IS NULL OR birth_date ~ '^[0-9]{4}(-[0-9]{2}(-[0-9]{2})?)?$'` [name: 'ck_members_birth_date_fmt_valid']
  }

  */
```

I hope you will merge and publish this fix any time soon, because my team extremely depends on this for our workflow.
Let me know if I missed something (and need to change something). And please keep me up-to-date on the publish status (perhaps just mention via this PR).
Thank you very much! We really appreciate it! Cheers!
