### PR TITLE
feat: make indentation size configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,22 @@ Format Document
 ---
 
 ## Configuration
+- **Indentation Size:** By default the formatter indents using the editor's own indentation settings (`editor.tabSize` / `editor.insertSpaces`), so it respects whatever you use for the rest of your files. To force a specific number of spaces regardless of the editor setting, use `dbml-formatter.indentSize`:
+  ```jsonc
+  {
+    // Force 4 spaces per level for DBML files
+    "dbml-formatter.indentSize": 4
+  }
+  ```
+  Leave it unset (`null`) to fall back to `editor.tabSize`. You can also scope the editor setting to DBML only:
+  ```jsonc
+  {
+    "[dbml]": {
+      "editor.tabSize": 4
+    }
+  }
+  ```
+  When the editor is configured to indent with tabs (`editor.insertSpaces` is `false`), the formatter emits one tab per level and `indentSize` is ignored.
 - **Error Handling:** If the parser encounters invalid DBML, the formatter will notify you in VS Code with an error message.
 
 ---

--- a/extension.js
+++ b/extension.js
@@ -123,9 +123,31 @@ function insertNewLinesBetweenBlocks(lines) {
   return result;
 }
 
+function resolveIndentStr(document, options) {
+  const config = vscode.workspace.getConfiguration("dbml-formatter", document.uri);
+  const configuredSize = config.get("indentSize");
+
+  // A positive `indentSize` setting takes precedence; otherwise fall back to
+  // the editor's own indentation options (`editor.tabSize` / `editor.insertSpaces`),
+  // which VS Code passes in via `options`.
+  const useSpaces = options ? options.insertSpaces : true;
+  if (!useSpaces) {
+    return "\t";
+  }
+
+  const size =
+    typeof configuredSize === "number" && configuredSize > 0
+      ? configuredSize
+      : options && options.tabSize
+      ? options.tabSize
+      : 2;
+
+  return " ".repeat(size);
+}
+
 function activate(context) {
   const formatter = {
-    provideDocumentFormattingEdits(document) {
+    provideDocumentFormattingEdits(document, options) {
       const fullText = document.getText();
       try {
         const parser = new Parser();
@@ -155,7 +177,7 @@ function activate(context) {
       }
 
       let indentLevel = 0;
-      const INDENT_STR = "  ";
+      const INDENT_STR = resolveIndentStr(document, options);
       const lines = fullText.split("\n");
       const newLines = lines.map((line) => {
         const { newLine, newIndentLevel } = formatLine(

--- a/package.json
+++ b/package.json
@@ -47,7 +47,21 @@
           ".dbml"
         ]
       }
-    ]
+    ],
+    "configuration": {
+      "title": "DBML Formatter",
+      "properties": {
+        "dbml-formatter.indentSize": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "default": null,
+          "minimum": 1,
+          "markdownDescription": "Number of spaces to use per indentation level. When left unset (`null`), the formatter falls back to the editor's `#editor.tabSize#` setting. Ignored when the editor is configured to indent with tabs (`#editor.insertSpaces#` is `false`), in which case a tab character is used per level."
+        }
+      }
+    }
   },
   "scripts": {
     "publish": "vsce publish",


### PR DESCRIPTION
## What & why

Indentation is currently hardcoded to two spaces:

```js
const INDENT_STR = "  ";
```

This PR makes the indent configurable so people who indent their `.dbml` files with 4 spaces (or tabs) get output that matches the rest of their codebase.

## How

Two complementary layers, so it works out of the box **and** can be forced:

1. **Respect the editor's indentation options.** `provideDocumentFormattingEdits` now uses the `options` argument VS Code already passes in (`options.tabSize` / `options.insertSpaces`). So a user who sets `editor.tabSize: 4` — globally or scoped with `"[dbml]": { "editor.tabSize": 4 }` — gets 4-space indents with no extra config. Tab-indented editors (`insertSpaces: false`) now get one tab per level instead of two spaces.

2. **A dedicated `dbml-formatter.indentSize` setting** (registered under `contributes.configuration`). When set to a positive number it overrides the editor `tabSize`; left unset (`null`, the default) it falls back to the editor setting. Ignored when the editor indents with tabs.

Resolution order, in one place (`resolveIndentStr`):

```
insertSpaces === false        -> "\t"
dbml-formatter.indentSize > 0 -> that many spaces
otherwise                     -> editor.tabSize spaces (default 2)
```

Default behavior is unchanged: with no settings touched, output is still two spaces.

## Testing

- `node --check extension.js` passes; `package.json` is valid JSON.
- Verified `resolveIndentStr` against a mocked `vscode` for: setting wins, unset→tabSize (2 and 4), `0` ignored, tabs→`\t`, and the no-options fallback. All pass.

## Notes

- Documented under **Configuration** in the README.
- Happy to drop layer 1 (honoring the editor options) or layer 2 (the dedicated setting) if you'd prefer a smaller surface — just say which you'd like to keep.
